### PR TITLE
Remove udev rule for TEE

### DIFF
--- a/modules/services/caml-crush/default.nix
+++ b/modules/services/caml-crush/default.nix
@@ -192,13 +192,5 @@ in {
     };
 
     environment.systemPackages = builtins.map mkPkcs11ToolWrapper libnames;
-
-    # Permissions for /dev/tee0
-    # TODO: Create separate group for tee-client, and add user of the
-    #       caml-crush service to that group.
-    # TODO: Possibly move to flake module
-    services.udev.extraRules = ''
-      SUBSYSTEM=="tee",KERNEL=="tee0",GROUP="${cfg.group}"
-    '';
   };
 }


### PR DESCRIPTION
udev rules should be configured by downstream projects which take this as a dependency.