### PR TITLE
Add option for service (pkcs11proxyd) socket type, address and port configuration

### DIFF
--- a/modules/services/caml-crush/pkcs11proxyd.conf
+++ b/modules/services/caml-crush/pkcs11proxyd.conf
@@ -17,8 +17,15 @@ netplex {
     protocol {
       name = "rpc_pkcs11";
       address {
-        type = "internet";
-        bind = "127.0.0.1:4444";
+        (* For the sake of consistency both lines are fully replaced
+           although protocolAddressType could be just "value"-replaced.
+
+           protocolAddressBind cannnot be "value"-replaced *cleanly* due:
+             - protocolAddressType value "internet" would require "bind"-key
+             - protocolAddressType value "local" would require "path"-key.
+        *)
+        @protocolAddressType@
+        @protocolAddressBind@
       };
     };
     processor {


### PR DESCRIPTION
Pull request add Nixos option for service (pkcs11proxyd) socket type, address and port configuration. 

Note: _Type_ is sanity check, but it does not select a sensible default by provided type! If type is set to _local_ then user needs to provide a valid address (path) to UNIX domain socket.

#### Tested
Connects to OPTEE on Orin NX with default options. 

Also build with various options and _pkcs11proxyd.conf_-files seems generate fine.
`server.protocol.type = "INVALID";`
`server.protocol.address = "192.168.101.2:4444";`
`server.protocol.type = "internet"; server.protocol.address = "192.168.101.2:4444";`
`server.protocol.type = "local";`
 