### PR TITLE
ocamlnet issue for ocml version > 5 fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,16 +53,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "lastModified": 1722869614,
+        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,8 @@
 
   inputs = {
     # Nixpkgs
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    #nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:tiiuae/nixpkgs/nixos-unstable-xdg-ffado-2"; #"flake:mylocalnixpkgs"; #
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
@@ -27,7 +28,9 @@
     flake-parts.lib.mkFlake
     {
       inherit inputs;
-    } {
+    } 
+    
+    {
       systems = [
         "x86_64-linux"
         "aarch64-linux"

--- a/pkgs/caml-crush/default.nix
+++ b/pkgs/caml-crush/default.nix
@@ -4,8 +4,10 @@
 {
   stdenv,
   lib,
+  pkgs,
   fetchFromGitHub,
   ocamlPackages,
+  callPackage,
   coccinelle,
   autoreconfHook,
   libtirpc,
@@ -20,6 +22,12 @@
     camlp4
     config-file
     ;
+    
+  # The old coccinelle is needed for ghaf caml crush library
+  coccinelle = callPackage ../coccinelle {};
+  # Fix no ocamlnet after ocaml 5.0 error
+  # choose the ocaml version you want to use
+  ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
   ocamlnet = ocamlPackages.ocamlnet.overrideAttrs (_old: {
     # Fix broken ocamlrpcgen
     dontStrip = true;

--- a/pkgs/coccinelle/default.nix
+++ b/pkgs/coccinelle/default.nix
@@ -1,0 +1,85 @@
+{ 
+ stdenv,
+ lib,
+ fetchFromGitHub,
+ fetchpatch,
+ ocamlPackages,
+ pkg-config,
+ autoreconfHook,
+ pkgs
+}: let
+  inherit
+    (ocamlPackages)
+    ocaml
+    findlib
+    camlidl
+    camlp4
+    config-file
+    ;
+  ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14; 
+  in
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "coccinelle";
+      version = "1.1.1";
+
+      src = fetchFromGitHub {
+        repo = "coccinelle";
+        rev = finalAttrs.version;
+        owner = "coccinelle";
+        hash = "sha256-rS9Ktp/YcXF0xUtT4XZtH5F9huvde0vRztY7vGtyuqY=";
+      };
+
+      patches = [
+        # Fix data path lookup.
+        # https://github.com/coccinelle/coccinelle/pull/270
+        (fetchpatch {
+          url = "https://github.com/coccinelle/coccinelle/commit/540888ff426e0b1f7907b63ce26e712d1fc172cc.patch";
+          sha256 = "sha256-W8RNIWDAC3lQ5bG+gD50r7x919JIcZRpt3QSOSMWpW4=";
+        })
+      ];
+
+
+      nativeBuildInputs = with ocamlPackages; [
+        autoreconfHook
+        pkg-config
+        ocaml
+        findlib
+        menhir
+      ];
+
+      buildInputs = with ocamlPackages; [
+        ocaml_pcre
+        parmap
+        pyml
+        stdcompat
+      ];
+
+      strictDeps = true;
+
+      postPatch = ''
+        # Ensure dependencies from Nixpkgs are picked up.
+        rm -rf bundles/
+      '';
+
+      meta = {
+        description = "Program to apply semantic patches to C code";
+        longDescription = ''
+          Coccinelle is a program matching and transformation engine which
+          provides the language SmPL (Semantic Patch Language) for
+          specifying desired matches and transformations in C code.
+          Coccinelle was initially targeted towards performing collateral
+          evolutions in Linux.  Such evolutions comprise the changes that
+          are needed in client code in response to evolutions in library
+          APIs, and may include modifications such as renaming a function,
+          adding a function argument whose value is somehow
+          context-dependent, and reorganizing a data structure.  Beyond
+          collateral evolutions, Coccinelle is successfully used (by us
+          and others) for finding and fixing bugs in systems code.
+        '';
+
+        homepage = "https://coccinelle.gitlabpages.inria.fr/website/";
+        license = lib.licenses.gpl2Only;
+        platforms = lib.platforms.unix;
+        maintainers = [ lib.maintainers.thoughtpolice ];
+      };
+})

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,6 +6,7 @@
 {
   perSystem = {pkgs, ...}: {
     packages = {
+      coccinelle = pkgs.callPackage ./coccinelle {};
       caml-crush = pkgs.callPackage ./caml-crush {};
     };
   };


### PR DESCRIPTION
When trying to merge latest ghaf with fog-ghaf the issue raised with ocamlnet used in this package as it is not available for ocaml versions later than 5. On previous ghaf the nixpkgs already used 4.14 of ocaml so ocamlnet worked without issues. But new ghaf is using 5.11 of the ocaml that causes this issue. 
Problem is due to not defining which ocaml version being used. 
The document for ocaml in nixpkgs doc/languages-frameworks/ocaml.section.md clearly states that the ocaml version must be set before use as below:
 # choose the ocaml version you want to use
 ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
